### PR TITLE
Update Payment Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ Para mantenerte actualizado sobre los cambios a esta lista, podés forkear el re
 
 ### Pagos
 
-* MercadoPago - https://github.com/mercadopago/cart-magento2
-* Mobbex - https://github.com/mobbexco/magento-2
-* TodoPago - https://github.com/TodoPago/Plugin-Magento2
-* Uala Bis - https://github.com/Uala-Developers/ualabis-magento
+* Go Cuotas (m2.4.x) - https://github.com/MageRocket/module-gocuotas
 * Go Cuotas - https://github.com/federicosoich/module-go-cuotas-payment
+* MercadoPago - https://github.com/mercadopago/adb-payment
+* Mobbex - https://github.com/mobbexco/magento-2
+* Uala Bis - https://github.com/Uala-Developers/ualabis-magento
 * Wibond - https://github.com/itwibond/module-wibond
-
 
 ### ERP
 


### PR DESCRIPTION
### Descripción
Actualizo listado de Pasarelas de Pago. Sumo la nueva versión del módulo de Go Cuotas para m2.4.x (php 7.4 / 8.2)
Dentro de unos dias sumo la versión del modulo para m2.3.3 <=  2.3.6 con soporte < php7.3
Removí Todo Pago ya que no funciona más, ordené alfabeticamente y actualize el link del modulo de MercadoPago